### PR TITLE
Capture fields with unquoted data

### DIFF
--- a/src/log_entry.py
+++ b/src/log_entry.py
@@ -42,7 +42,7 @@ class LogEntry:
         if string != None:
             a = re.findall(r"\[[^\]]+]", string)
             for i in a:
-                b = re.findall(r"\[([^ ]+) \"(.*)\"\]$", i)
+                b = re.findall(r"\[([^ ]+) \"?(.*)\"?\]$", i)
                 if len(b) == 0:
                     continue
                 b = b[0]


### PR DESCRIPTION
Resolved not capturing fields if the value was not quoted. Example wa…s "[client 192.168.100.100]" not being caught by the parser. Specifying the optional quote resolved the issue.