### PR TITLE
Create field separator argument

### DIFF
--- a/modsec-log-parser.py
+++ b/modsec-log-parser.py
@@ -25,12 +25,14 @@ import argparse
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--summary', type=str)
+    parser.add_argument('--delim', type=str)
     parser.add_argument('files', nargs='*')
     args = parser.parse_args()
     print(args.files, args.summary)
 
     files = args.files
     summary = args.summary
+    delim = args.delim
     if len(files) == 0:
         files = "/dev/stdin"
     if len(summary) == 0:
@@ -47,7 +49,7 @@ def main():
         z = ""
 	for xx in summary.split(","):
             if len(z) > 0:
-                z = z + " "
+                z = z + str(delim) 
             z = z + str(i.__dict__[xx])
 
 	if i.id in ar:


### PR DESCRIPTION
Allow use of an arbitrary field separator string in output because spaces are not unique to field separation.